### PR TITLE
Enhance CI/CD workflow for cross-platform builds and fixed pathing for building on Windows

### DIFF
--- a/.github/workflows/build-glm.yml
+++ b/.github/workflows/build-glm.yml
@@ -1,4 +1,4 @@
-name: Build GLM (Windows)
+name: Build GLM
 
 # Manually triggered so you can pick which GLM branch/tag to build.
 on:
@@ -10,7 +10,7 @@ on:
         default: 'v4alpha'
 
 jobs:
-  build:
+  build-windows:
     runs-on: windows-latest
     defaults:
       run:
@@ -193,3 +193,167 @@ jobs:
         with:
           name: glm-windows-${{ inputs.glm_ref }}
           path: glm_dist
+
+  # ==========================================================================
+  # Linux and macOS don't use the ancillary/ from-source pipeline at all -
+  # build_glm.sh only invokes it on Msys (Windows). On these platforms the
+  # netcdf-c/netcdf-fortran/gd dependencies come from the system package
+  # manager instead, which is also how this project ships its own .deb
+  # package (see debian/control) and documents macOS builds (README.Macintosh).
+  #
+  # build_env.inc (staged below, same as Windows) auto-detects whether those
+  # packages are actually found (via nc-config/nf-config/gd.h) and only
+  # falls back to building from ancillary/ if something's missing - so we
+  # stage ancillary/ here too, purely as a safety net, not because it's
+  # expected to run.
+  # ==========================================================================
+
+  build-linux:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+    env:
+      ROOT: ${{ github.workspace }}
+
+    steps:
+      - name: Install build dependencies (apt)
+        run: |
+          sudo apt-get update
+          # libx11-dev is only needed for --xdisp (the interactive plot
+          # window); drop it (and WITH_XPLOTS below) if you don't need that.
+          sudo apt-get install -y gfortran gcc make git \
+            libnetcdf-dev libnetcdff-dev libgd-dev libx11-dev
+
+      - name: Checkout GLM
+        uses: actions/checkout@v4
+        with:
+          repository: AquaticEcoDynamics/GLM
+          ref: ${{ inputs.glm_ref }}
+          path: GLM
+
+      - name: Checkout AED_Tools and sibling libraries
+        run: |
+          cd "$ROOT"
+          for repo in AED_Tools libaed-water libaed-benthic libaed-demo libaed-api libutil libplot; do
+            git clone --depth 1 "https://github.com/AquaticEcoDynamics/${repo}.git"
+          done
+
+      - name: Stage build_env.inc, build_aedlibs.inc and ancillary/ (fallback only)
+        run: |
+          cd "$ROOT"
+          cp AED_Tools/build_env.inc .
+          cp AED_Tools/build_aedlibs.inc .
+          cp -r AED_Tools/ancillary .
+
+      - name: Build GLM
+        run: |
+          cd "$ROOT/GLM"
+          ./build_glm.sh
+
+      - name: Verify glm runs
+        run: |
+          cd "$ROOT/GLM"
+          ./glm --version
+
+      - name: Assemble distributable folder
+        run: |
+          mkdir -p "$ROOT/glm_dist"
+          cp "$ROOT/GLM/glm" "$ROOT/glm_dist/"
+          # This binary is dynamically linked against apt's shared libs, so
+          # unlike the Windows build it's only guaranteed to run on a
+          # matching distro/version - not a portable bundle. Record what it
+          # actually needs at runtime for reference.
+          ldd "$ROOT/GLM/glm" > "$ROOT/glm_dist/ldd-dependencies.txt" || true
+
+      - name: Upload glm_dist artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: glm-linux-${{ inputs.glm_ref }}
+          path: glm_dist
+
+  build-macos:
+    runs-on: macos-latest
+    defaults:
+      run:
+        shell: bash
+    env:
+      ROOT: ${{ github.workspace }}
+
+    steps:
+      - name: Install build dependencies (Homebrew)
+        run: |
+          brew install gcc netcdf netcdf-fortran gd
+
+      - name: Resolve versioned FC/CC and put them on PATH
+        run: |
+          # Homebrew's gcc formula installs versioned binaries (gfortran-14,
+          # gcc-14, ...), not a plain "gfortran"/"gcc" - resolve whatever
+          # version actually got installed instead of hardcoding one.
+          GCC_VER=$(brew list --versions gcc | awk '{print $2}' | cut -d. -f1)
+          echo "FC=gfortran-${GCC_VER}" >> "$GITHUB_ENV"
+          echo "CC=gcc-${GCC_VER}" >> "$GITHUB_ENV"
+          echo "HOMEBREW=true" >> "$GITHUB_ENV"
+
+      - name: Checkout GLM
+        uses: actions/checkout@v4
+        with:
+          repository: AquaticEcoDynamics/GLM
+          ref: ${{ inputs.glm_ref }}
+          path: GLM
+
+      - name: Checkout AED_Tools and sibling libraries
+        run: |
+          cd "$ROOT"
+          for repo in AED_Tools libaed-water libaed-benthic libaed-demo libaed-api libutil libplot; do
+            git clone --depth 1 "https://github.com/AquaticEcoDynamics/${repo}.git"
+          done
+
+      - name: Stage build_env.inc, build_aedlibs.inc and ancillary/ (fallback only)
+        run: |
+          cd "$ROOT"
+          cp AED_Tools/build_env.inc .
+          cp AED_Tools/build_aedlibs.inc .
+          cp -r AED_Tools/ancillary .
+
+      # build_env.inc's gd detection only checks the literal path
+      # /usr/include/gd.h, which Homebrew never installs to (it uses
+      # /opt/homebrew or /usr/local). Left as-is, that makes it fall back to
+      # building gd from source via ancillary/ every run, which is slow and
+      # untested on macOS. Pointing HOMEBREW's gd.h at the path it checks
+      # avoids that - if /usr/include isn't writable on the runner, this
+      # step is harmless to skip; build_glm.sh will just fall back to
+      # ancillary/ instead.
+      - name: "Workaround: make Homebrew's gd.h visible to build_env.inc's detection"
+        run: |
+          GD_INCLUDE="$(brew --prefix gd)/include/gd.h"
+          sudo mkdir -p /usr/include 2>/dev/null || true
+          sudo cp "$GD_INCLUDE" /usr/include/gd.h 2>/dev/null || \
+            echo "could not stage /usr/include/gd.h - build_glm.sh will build gd from source via ancillary/ instead"
+
+      - name: Build GLM
+        run: |
+          cd "$ROOT/GLM"
+          ./build_glm.sh
+
+      - name: Verify glm runs
+        run: |
+          cd "$ROOT/GLM"
+          ./glm --version
+
+      - name: Assemble distributable folder
+        run: |
+          mkdir -p "$ROOT/glm_dist"
+          cp "$ROOT/GLM/glm" "$ROOT/glm_dist/"
+          # Dynamically linked against Homebrew's dylibs - portable to other
+          # Macs only if they also have the same Homebrew packages installed
+          # (or use the project's own macos/macpkg.sh to bundle them, which
+          # this job doesn't do yet).
+          otool -L "$ROOT/GLM/glm" > "$ROOT/glm_dist/otool-dependencies.txt" || true
+
+      - name: Upload glm_dist artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: glm-macos-${{ inputs.glm_ref }}
+          path: glm_dist
+          

--- a/.github/workflows/build-glm.yml
+++ b/.github/workflows/build-glm.yml
@@ -228,7 +228,7 @@ jobs:
       - name: Checkout GLM
         uses: actions/checkout@v4
         with:
-          repository: AquaticEcoDynamics/GLM
+          repository: limnotrack/GLM
           ref: ${{ inputs.glm_ref }}
           path: GLM
 
@@ -298,7 +298,7 @@ jobs:
       - name: Checkout GLM
         uses: actions/checkout@v4
         with:
-          repository: AquaticEcoDynamics/GLM
+          repository: limnotrack/GLM
           ref: ${{ inputs.glm_ref }}
           path: GLM
 

--- a/.github/workflows/build-glm.yml
+++ b/.github/workflows/build-glm.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Checkout GLM
         uses: actions/checkout@v4
         with:
-          repository: AquaticEcoDynamics/GLM
+          repository: limnotrack/GLM
           ref: ${{ inputs.glm_ref }}
           path: GLM
 

--- a/.github/workflows/build-glm.yml
+++ b/.github/workflows/build-glm.yml
@@ -7,11 +7,21 @@ on:
       glm_ref:
         description: 'GLM branch, tag, or commit to build'
         required: true
-        default: 'v4alpha'
+        default: 'master'
 
 jobs:
-  build-windows:
-    runs-on: windows-latest
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: windows-latest
+            name: windows
+          - os: ubuntu-latest
+            name: linux
+          - os: macos-latest
+            name: macos
+    runs-on: ${{ matrix.os }}
     defaults:
       run:
         shell: bash
@@ -23,26 +33,54 @@ jobs:
 
     steps:
       # ------------------------------------------------------------------
-      # 1. Toolchain: choco packages from GLM's README.Windows
+      # 1. Toolchain. Windows builds its C/Fortran dependency chain from
+      #    source (see the ancillary/ steps further down), so it only
+      #    needs the compilers themselves via choco. Linux and macOS get
+      #    netcdf-c/netcdf-fortran/gd from their system package manager
+      #    instead - same as how this project ships its own .deb package
+      #    (see debian/control) and documents macOS builds (README.Macintosh).
       # ------------------------------------------------------------------
-      - name: Install make/mingw/cmake via chocolatey
+      - name: "Toolchain (Windows): install make/mingw/cmake via chocolatey"
+        if: matrix.os == 'windows-latest'
         shell: pwsh
         run: |
           choco install -y make
           choco install -y mingw
           choco install -y cmake --installargs 'ADD_CMAKE_TO_PATH=System'
 
-      - name: Put mingw + cmake on PATH for later steps
+      - name: "Toolchain (Windows): put mingw + cmake on PATH for later steps"
+        if: matrix.os == 'windows-latest'
         run: |
           echo "C:\ProgramData\mingw64\mingw64\bin" >> "$GITHUB_PATH"
           echo "C:\Program Files\CMake\bin" >> "$GITHUB_PATH"
+
+      - name: "Toolchain (Linux): install via apt"
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          sudo apt-get update
+          # libx11-dev is only needed for --xdisp (the interactive plot
+          # window); drop it (and WITH_XPLOTS below) if you don't need that.
+          sudo apt-get install -y gfortran gcc make git \
+            libnetcdf-dev libnetcdff-dev libgd-dev libx11-dev
+
+      - name: "Toolchain (macOS): install via Homebrew"
+        if: matrix.os == 'macos-latest'
+        run: |
+          brew install gcc netcdf netcdf-fortran gd
+          # Homebrew's gcc formula installs versioned binaries (gfortran-14,
+          # gcc-14, ...), not a plain "gfortran"/"gcc" - resolve whatever
+          # version actually got installed instead of hardcoding one.
+          GCC_VER=$(brew list --versions gcc | awk '{print $2}' | cut -d. -f1)
+          echo "FC=gfortran-${GCC_VER}" >> "$GITHUB_ENV"
+          echo "CC=gcc-${GCC_VER}" >> "$GITHUB_ENV"
+          echo "HOMEBREW=true" >> "$GITHUB_ENV"
 
       - name: Sanity-check toolchain
         run: |
           gcc --version | head -1
           gfortran --version | head -1
           make --version | head -1
-          cmake --version | head -1
+          if [ "${{ matrix.os }}" = "windows-latest" ]; then cmake --version | head -1; fi
 
       # ------------------------------------------------------------------
       # 2. Checkout GLM at the chosen ref, plus the sibling repos it needs.
@@ -59,7 +97,29 @@ jobs:
       - name: Checkout AED_Tools and sibling libraries
         run: |
           cd "$ROOT"
-          for repo in AED_Tools libaed-water libaed-benthic libaed-demo libaed-api libutil libplot; do
+          # AED_Tools comes from limnotrack's fork, not upstream: it carries
+          # a netcdf-c/netcdf-fortran build fix (build_netcdf_c.inc/
+          # build_netcdf_f.inc -fpermissive, commit 5a9a1ff) not yet merged
+          # into AquaticEcoDynamics/AED_Tools. Switch this back to
+          # AquaticEcoDynamics/AED_Tools once that PR lands upstream.
+          git clone --depth 1 "https://github.com/limnotrack/AED_Tools.git"
+
+          # libaed-api and libaed2 are mutually exclusive, branch-specific
+          # dependencies, not universal ones:
+          #  - v4alpha has a WITH_API/libaed-api plugin feature; AED2 doesn't
+          #    exist there at all (no Makefile support, no build_glm.sh flag).
+          #  - master needs libaed2 (its GLM_CONFIG sets AED2=true by
+          #    default, and build_glm.sh unconditionally cd's into it when
+          #    that's set); it has no WITH_API/libaed-api concept.
+          # Cloning the wrong one is just wasted time; cloning neither is a
+          # hard build failure. Add more branches here as needed.
+          SIBLINGS="libaed-water libaed-benthic libaed-demo libutil libplot"
+          if [ "${{ inputs.glm_ref }}" = "v4alpha" ]; then
+            SIBLINGS="$SIBLINGS libaed-api"
+          else
+            SIBLINGS="$SIBLINGS libaed2"
+          fi
+          for repo in $SIBLINGS; do
             git clone --depth 1 "https://github.com/AquaticEcoDynamics/${repo}.git"
           done
 
@@ -68,7 +128,11 @@ jobs:
       #    NOT track: build_env.inc / build_aedlibs.inc (sourced by
       #    build_glm.sh) and the ancillary/ dependency-build pipeline.
       #    Both come from AED_Tools, which is the documented starting
-      #    point for AED/GLM builds.
+      #    point for AED/GLM builds. On Linux/macOS this is only a
+      #    fallback: build_env.inc auto-detects whether apt's/Homebrew's
+      #    netcdf-c/netcdf-fortran/gd are already found (via nc-config/
+      #    nf-config/gd.h) and only falls back to building from ancillary/
+      #    if something's missing.
       # ------------------------------------------------------------------
       - name: Stage build_env.inc, build_aedlibs.inc and ancillary/
         run: |
@@ -77,26 +141,16 @@ jobs:
           cp AED_Tools/build_aedlibs.inc .
           cp -r AED_Tools/ancillary .
 
-      # (a) build_glm.sh checks for "ancillary/windows/lib" and cd's into
-      #     "ancillary/windows", but the ancillary/ pipeline above produces
-      #     a flat ancillary/lib, ancillary/include, ancillary/bin layout
-      #     with no "windows" subfolder. Point it at the right path. This
-      #     runs every time (GLM itself isn't cached, unlike ancillary/).
-      - name: "Patch: build_glm.sh ancillary path"
-        run: |
-          sed -i \
-            -e 's#ancillary/windows/lib#ancillary/lib#' \
-            -e 's#cd ancillary/windows#cd ancillary#' \
-            "$ROOT/GLM/build_glm.sh"
-
       # ------------------------------------------------------------------
       # 4. Build the ancillary C/Fortran dependency chain: zlib, libaec,
       #    curl, hdf5, netcdf-c, netcdf-fortran, jpeg, libpng, freetype,
-      #    gd. This is the slow part (~20-30 min from cold), so it's
-      #    cached independently of the GLM source itself, and the
-      #    patches/workarounds below only need to run on a cache miss.
+      #    gd. Windows-only - this is the slow part (~20-30 min from
+      #    cold), so it's cached independently of the GLM source itself,
+      #    and the patches/workarounds below only need to run on a cache
+      #    miss.
       # ------------------------------------------------------------------
-      - name: Cache ancillary dependencies
+      - name: Cache ancillary dependencies (Windows only)
+        if: matrix.os == 'windows-latest'
         id: ancillary-cache
         uses: actions/cache@v4
         with:
@@ -109,47 +163,8 @@ jobs:
           # patches below, or if ancillary/sources/versions.inc changes.
           key: glm-ancillary-windows-v1-${{ hashFiles('ancillary/sources/versions.inc') }}
 
-      # (b) HDF5 1.14.x's _Float16 conversion code references FLT16_MAX,
-      #     which mingw-w64's headers don't define for this GCC version
-      #     (GCC does provide the value via the builtin __FLT16_MAX__).
-      - name: "Patch: HDF5 FLT16_MAX gap"
-        if: steps.ancillary-cache.outputs.cache-hit != 'true'
-        run: |
-          sed -i \
-            's#-DCMAKE_C_FLAGS="-I${FINALDIR}/include"#-DCMAKE_C_FLAGS="-I${FINALDIR}/include -DFLT16_MAX=__FLT16_MAX__"#' \
-            "$ROOT/ancillary/sources/scripts/build_extras.inc"
-
-      # (c) netcdf-c 4.9.2 fails a pointer-type check that GCC 14+ turned
-      #     into a hard error by default (mismatched struct stat / struct
-      #     _stat64 in dpathmgr.c, from newer mingw-w64 headers).
-      - name: "Patch: netcdf-c/netcdf-fortran strict pointer-type errors"
-        if: steps.ancillary-cache.outputs.cache-hit != 'true'
-        run: |
-          for f in "$ROOT/ancillary/sources/scripts/build_netcdf_c.inc" \
-                   "$ROOT/ancillary/sources/scripts/build_netcdf_f.inc"; do
-            sed -i '/-DCMAKE_BUILD_TYPE:STRING=Release \\/a\           -DCMAKE_C_FLAGS:STRING=-fpermissive \\' "$f"
-          done
-
-      # (d) The DKRZ gitlab mirror for libaec is prone to rate-limiting
-      #     anonymous/CI IPs (HTTP 429). Pre-fetch it from the GitHub
-      #     mirror instead and repackage it under the archive name/top
-      #     level directory name (libaec-v1.1.4) that build_extras.inc
-      #     expects, so the pipeline's own fetch step just finds it
-      #     already there and skips downloading it.
-      - name: "Workaround: pre-fetch libaec from GitHub mirror"
-        if: steps.ancillary-cache.outputs.cache-hit != 'true'
-        run: |
-          mkdir -p "$ROOT/ancillary/sources"
-          cd "$ROOT/ancillary/sources"
-          curl -sSL -o libaec.tmp.tar.gz \
-            "https://github.com/MathisRosenhauer/libaec/archive/refs/tags/v1.1.4.tar.gz"
-          tar xzf libaec.tmp.tar.gz
-          mv libaec-1.1.4 libaec-v1.1.4
-          tar czf libaec-v1.1.4.tar.gz libaec-v1.1.4
-          rm -rf libaec-v1.1.4 libaec.tmp.tar.gz
-
-      - name: Build ancillary dependencies
-        if: steps.ancillary-cache.outputs.cache-hit != 'true'
+      - name: Build ancillary dependencies (Windows only)
+        if: matrix.os == 'windows-latest' && steps.ancillary-cache.outputs.cache-hit != 'true'
         run: |
           cd "$ROOT/ancillary"
           export FINALDIR="$ROOT/ancillary"
@@ -160,6 +175,22 @@ jobs:
           export FC=gfortran
           ./build.sh --all
 
+      # build_env.inc's gd detection only checks the literal path
+      # /usr/include/gd.h, which Homebrew never installs to (it uses
+      # /opt/homebrew or /usr/local). Left as-is, that makes it fall back to
+      # building gd from source via ancillary/ every run, which is slow and
+      # untested on macOS. Pointing Homebrew's gd.h at the path it checks
+      # avoids that - if /usr/include isn't writable on the runner, this
+      # step is harmless to skip; build_glm.sh will just fall back to
+      # ancillary/ instead.
+      - name: "Workaround: make Homebrew's gd.h visible to build_env.inc's detection (macOS only)"
+        if: matrix.os == 'macos-latest'
+        run: |
+          GD_INCLUDE="$(brew --prefix gd)/include/gd.h"
+          sudo mkdir -p /usr/include 2>/dev/null || true
+          sudo cp "$GD_INCLUDE" /usr/include/gd.h 2>/dev/null || \
+            echo "could not stage /usr/include/gd.h - build_glm.sh will build gd from source via ancillary/ instead"
+
       # ------------------------------------------------------------------
       # 5. Build GLM itself.
       # ------------------------------------------------------------------
@@ -168,192 +199,48 @@ jobs:
           cd "$ROOT/GLM"
           ./build_glm.sh
 
-      - name: Verify glm.exe runs
-        run: |
-          cd "$ROOT/GLM"
-          PATH="$ROOT/ancillary/bin:$PATH" ./glm.exe --version
-
-      # ------------------------------------------------------------------
-      # 6. Package glm.exe with the DLLs it needs at runtime so the
-      #    artifact is self-contained (no PATH setup required).
-      # ------------------------------------------------------------------
-      - name: Assemble distributable folder
-        run: |
-          mkdir -p "$ROOT/glm_dist"
-          cp "$ROOT/GLM/glm.exe" "$ROOT/glm_dist/"
-          cp "$ROOT/ancillary/bin/libgd.dll" "$ROOT/glm_dist/"
-          cp "$ROOT/ancillary/bin/libnetcdf.dll" "$ROOT/glm_dist/"
-          cp "C:/ProgramData/mingw64/mingw64/bin/libgfortran-5.dll" "$ROOT/glm_dist/"
-          cp "C:/ProgramData/mingw64/mingw64/bin/libquadmath-0.dll" "$ROOT/glm_dist/"
-          cp "C:/ProgramData/mingw64/mingw64/bin/libgcc_s_seh-1.dll" "$ROOT/glm_dist/"
-          cp "C:/ProgramData/mingw64/mingw64/bin/libwinpthread-1.dll" "$ROOT/glm_dist/"
-
-      - name: Upload glm_dist artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: glm-windows-${{ inputs.glm_ref }}
-          path: glm_dist
-
-  # ==========================================================================
-  # Linux and macOS don't use the ancillary/ from-source pipeline at all -
-  # build_glm.sh only invokes it on Msys (Windows). On these platforms the
-  # netcdf-c/netcdf-fortran/gd dependencies come from the system package
-  # manager instead, which is also how this project ships its own .deb
-  # package (see debian/control) and documents macOS builds (README.Macintosh).
-  #
-  # build_env.inc (staged below, same as Windows) auto-detects whether those
-  # packages are actually found (via nc-config/nf-config/gd.h) and only
-  # falls back to building from ancillary/ if something's missing - so we
-  # stage ancillary/ here too, purely as a safety net, not because it's
-  # expected to run.
-  # ==========================================================================
-
-  build-linux:
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        shell: bash
-    env:
-      ROOT: ${{ github.workspace }}
-
-    steps:
-      - name: Install build dependencies (apt)
-        run: |
-          sudo apt-get update
-          # libx11-dev is only needed for --xdisp (the interactive plot
-          # window); drop it (and WITH_XPLOTS below) if you don't need that.
-          sudo apt-get install -y gfortran gcc make git \
-            libnetcdf-dev libnetcdff-dev libgd-dev libx11-dev
-
-      - name: Checkout GLM
-        uses: actions/checkout@v4
-        with:
-          repository: limnotrack/GLM
-          ref: ${{ inputs.glm_ref }}
-          path: GLM
-
-      - name: Checkout AED_Tools and sibling libraries
-        run: |
-          cd "$ROOT"
-          for repo in AED_Tools libaed-water libaed-benthic libaed-demo libaed-api libutil libplot; do
-            git clone --depth 1 "https://github.com/AquaticEcoDynamics/${repo}.git"
-          done
-
-      - name: Stage build_env.inc, build_aedlibs.inc and ancillary/ (fallback only)
-        run: |
-          cd "$ROOT"
-          cp AED_Tools/build_env.inc .
-          cp AED_Tools/build_aedlibs.inc .
-          cp -r AED_Tools/ancillary .
-
-      - name: Build GLM
-        run: |
-          cd "$ROOT/GLM"
-          ./build_glm.sh
-
       - name: Verify glm runs
         run: |
           cd "$ROOT/GLM"
-          ./glm --version
+          if [ "${{ matrix.os }}" = "windows-latest" ]; then
+            PATH="$ROOT/ancillary/bin:$PATH" ./glm.exe --version
+          else
+            ./glm --version
+          fi
 
+      # ------------------------------------------------------------------
+      # 6. Package the binary for upload. Windows gets its runtime DLLs
+      #    bundled alongside it so the artifact is self-contained; Linux
+      #    and macOS binaries are dynamically linked against system
+      #    packages (apt/Homebrew) instead, so they're only guaranteed to
+      #    run on a matching machine, not a portable bundle - ldd/otool
+      #    output is recorded alongside them for reference.
+      # ------------------------------------------------------------------
       - name: Assemble distributable folder
         run: |
           mkdir -p "$ROOT/glm_dist"
-          cp "$ROOT/GLM/glm" "$ROOT/glm_dist/"
-          # This binary is dynamically linked against apt's shared libs, so
-          # unlike the Windows build it's only guaranteed to run on a
-          # matching distro/version - not a portable bundle. Record what it
-          # actually needs at runtime for reference.
-          ldd "$ROOT/GLM/glm" > "$ROOT/glm_dist/ldd-dependencies.txt" || true
+          case "${{ matrix.os }}" in
+            windows-latest)
+              cp "$ROOT/GLM/glm.exe" "$ROOT/glm_dist/"
+              cp "$ROOT/ancillary/bin/libgd.dll" "$ROOT/glm_dist/"
+              cp "$ROOT/ancillary/bin/libnetcdf.dll" "$ROOT/glm_dist/"
+              cp "C:/ProgramData/mingw64/mingw64/bin/libgfortran-5.dll" "$ROOT/glm_dist/"
+              cp "C:/ProgramData/mingw64/mingw64/bin/libquadmath-0.dll" "$ROOT/glm_dist/"
+              cp "C:/ProgramData/mingw64/mingw64/bin/libgcc_s_seh-1.dll" "$ROOT/glm_dist/"
+              cp "C:/ProgramData/mingw64/mingw64/bin/libwinpthread-1.dll" "$ROOT/glm_dist/"
+              ;;
+            ubuntu-latest)
+              cp "$ROOT/GLM/glm" "$ROOT/glm_dist/"
+              ldd "$ROOT/GLM/glm" > "$ROOT/glm_dist/ldd-dependencies.txt" || true
+              ;;
+            macos-latest)
+              cp "$ROOT/GLM/glm" "$ROOT/glm_dist/"
+              otool -L "$ROOT/GLM/glm" > "$ROOT/glm_dist/otool-dependencies.txt" || true
+              ;;
+          esac
 
       - name: Upload glm_dist artifact
         uses: actions/upload-artifact@v4
         with:
-          name: glm-linux-${{ inputs.glm_ref }}
+          name: glm-${{ matrix.name }}-${{ inputs.glm_ref }}
           path: glm_dist
-
-  build-macos:
-    runs-on: macos-latest
-    defaults:
-      run:
-        shell: bash
-    env:
-      ROOT: ${{ github.workspace }}
-
-    steps:
-      - name: Install build dependencies (Homebrew)
-        run: |
-          brew install gcc netcdf netcdf-fortran gd
-
-      - name: Resolve versioned FC/CC and put them on PATH
-        run: |
-          # Homebrew's gcc formula installs versioned binaries (gfortran-14,
-          # gcc-14, ...), not a plain "gfortran"/"gcc" - resolve whatever
-          # version actually got installed instead of hardcoding one.
-          GCC_VER=$(brew list --versions gcc | awk '{print $2}' | cut -d. -f1)
-          echo "FC=gfortran-${GCC_VER}" >> "$GITHUB_ENV"
-          echo "CC=gcc-${GCC_VER}" >> "$GITHUB_ENV"
-          echo "HOMEBREW=true" >> "$GITHUB_ENV"
-
-      - name: Checkout GLM
-        uses: actions/checkout@v4
-        with:
-          repository: limnotrack/GLM
-          ref: ${{ inputs.glm_ref }}
-          path: GLM
-
-      - name: Checkout AED_Tools and sibling libraries
-        run: |
-          cd "$ROOT"
-          for repo in AED_Tools libaed-water libaed-benthic libaed-demo libaed-api libutil libplot; do
-            git clone --depth 1 "https://github.com/AquaticEcoDynamics/${repo}.git"
-          done
-
-      - name: Stage build_env.inc, build_aedlibs.inc and ancillary/ (fallback only)
-        run: |
-          cd "$ROOT"
-          cp AED_Tools/build_env.inc .
-          cp AED_Tools/build_aedlibs.inc .
-          cp -r AED_Tools/ancillary .
-
-      # build_env.inc's gd detection only checks the literal path
-      # /usr/include/gd.h, which Homebrew never installs to (it uses
-      # /opt/homebrew or /usr/local). Left as-is, that makes it fall back to
-      # building gd from source via ancillary/ every run, which is slow and
-      # untested on macOS. Pointing HOMEBREW's gd.h at the path it checks
-      # avoids that - if /usr/include isn't writable on the runner, this
-      # step is harmless to skip; build_glm.sh will just fall back to
-      # ancillary/ instead.
-      - name: "Workaround: make Homebrew's gd.h visible to build_env.inc's detection"
-        run: |
-          GD_INCLUDE="$(brew --prefix gd)/include/gd.h"
-          sudo mkdir -p /usr/include 2>/dev/null || true
-          sudo cp "$GD_INCLUDE" /usr/include/gd.h 2>/dev/null || \
-            echo "could not stage /usr/include/gd.h - build_glm.sh will build gd from source via ancillary/ instead"
-
-      - name: Build GLM
-        run: |
-          cd "$ROOT/GLM"
-          ./build_glm.sh
-
-      - name: Verify glm runs
-        run: |
-          cd "$ROOT/GLM"
-          ./glm --version
-
-      - name: Assemble distributable folder
-        run: |
-          mkdir -p "$ROOT/glm_dist"
-          cp "$ROOT/GLM/glm" "$ROOT/glm_dist/"
-          # Dynamically linked against Homebrew's dylibs - portable to other
-          # Macs only if they also have the same Homebrew packages installed
-          # (or use the project's own macos/macpkg.sh to bundle them, which
-          # this job doesn't do yet).
-          otool -L "$ROOT/GLM/glm" > "$ROOT/glm_dist/otool-dependencies.txt" || true
-
-      - name: Upload glm_dist artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: glm-macos-${{ inputs.glm_ref }}
-          path: glm_dist
-          

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -1,0 +1,195 @@
+name: Build GLM (Windows)
+
+# Manually triggered so you can pick which GLM branch/tag to build.
+on:
+  workflow_dispatch:
+    inputs:
+      glm_ref:
+        description: 'GLM branch, tag, or commit to build'
+        required: true
+        default: 'v4alpha'
+
+jobs:
+  build:
+    runs-on: windows-latest
+    defaults:
+      run:
+        shell: bash
+    env:
+      # Everything below is checked out/built as siblings under this folder,
+      # matching the layout build_glm.sh expects (GLM, ancillary, libaed-*,
+      # libutil, libplot all next to each other).
+      ROOT: ${{ github.workspace }}
+
+    steps:
+      # ------------------------------------------------------------------
+      # 1. Toolchain: choco packages from GLM's README.Windows
+      # ------------------------------------------------------------------
+      - name: Install make/mingw/cmake via chocolatey
+        shell: pwsh
+        run: |
+          choco install -y make
+          choco install -y mingw
+          choco install -y cmake --installargs 'ADD_CMAKE_TO_PATH=System'
+
+      - name: Put mingw + cmake on PATH for later steps
+        run: |
+          echo "C:\ProgramData\mingw64\mingw64\bin" >> "$GITHUB_PATH"
+          echo "C:\Program Files\CMake\bin" >> "$GITHUB_PATH"
+
+      - name: Sanity-check toolchain
+        run: |
+          gcc --version | head -1
+          gfortran --version | head -1
+          make --version | head -1
+          cmake --version | head -1
+
+      # ------------------------------------------------------------------
+      # 2. Checkout GLM at the chosen ref, plus the sibling repos it needs.
+      #    build_glm.sh assumes GLM sits next to AED_Tools/libaed-*/libutil/
+      #    libplot in one common parent directory (this workspace root).
+      # ------------------------------------------------------------------
+      - name: Checkout GLM
+        uses: actions/checkout@v4
+        with:
+          repository: AquaticEcoDynamics/GLM
+          ref: ${{ inputs.glm_ref }}
+          path: GLM
+
+      - name: Checkout AED_Tools and sibling libraries
+        run: |
+          cd "$ROOT"
+          for repo in AED_Tools libaed-water libaed-benthic libaed-demo libaed-api libutil libplot; do
+            git clone --depth 1 "https://github.com/AquaticEcoDynamics/${repo}.git"
+          done
+
+      # ------------------------------------------------------------------
+      # 3. Stage the files build_glm.sh needs but that GLM's own repo does
+      #    NOT track: build_env.inc / build_aedlibs.inc (sourced by
+      #    build_glm.sh) and the ancillary/ dependency-build pipeline.
+      #    Both come from AED_Tools, which is the documented starting
+      #    point for AED/GLM builds.
+      # ------------------------------------------------------------------
+      - name: Stage build_env.inc, build_aedlibs.inc and ancillary/
+        run: |
+          cd "$ROOT"
+          cp AED_Tools/build_env.inc .
+          cp AED_Tools/build_aedlibs.inc .
+          cp -r AED_Tools/ancillary .
+
+      # (a) build_glm.sh checks for "ancillary/windows/lib" and cd's into
+      #     "ancillary/windows", but the ancillary/ pipeline above produces
+      #     a flat ancillary/lib, ancillary/include, ancillary/bin layout
+      #     with no "windows" subfolder. Point it at the right path. This
+      #     runs every time (GLM itself isn't cached, unlike ancillary/).
+      - name: "Patch: build_glm.sh ancillary path"
+        run: |
+          sed -i \
+            -e 's#ancillary/windows/lib#ancillary/lib#' \
+            -e 's#cd ancillary/windows#cd ancillary#' \
+            "$ROOT/GLM/build_glm.sh"
+
+      # ------------------------------------------------------------------
+      # 4. Build the ancillary C/Fortran dependency chain: zlib, libaec,
+      #    curl, hdf5, netcdf-c, netcdf-fortran, jpeg, libpng, freetype,
+      #    gd. This is the slow part (~20-30 min from cold), so it's
+      #    cached independently of the GLM source itself, and the
+      #    patches/workarounds below only need to run on a cache miss.
+      # ------------------------------------------------------------------
+      - name: Cache ancillary dependencies
+        id: ancillary-cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ${{ github.workspace }}/ancillary/lib
+            ${{ github.workspace }}/ancillary/include
+            ${{ github.workspace }}/ancillary/bin
+            ${{ github.workspace }}/ancillary/share
+          # Bump the trailing version suffix if you change any of the
+          # patches below, or if ancillary/sources/versions.inc changes.
+          key: glm-ancillary-windows-v1-${{ hashFiles('ancillary/sources/versions.inc') }}
+
+      # (b) HDF5 1.14.x's _Float16 conversion code references FLT16_MAX,
+      #     which mingw-w64's headers don't define for this GCC version
+      #     (GCC does provide the value via the builtin __FLT16_MAX__).
+      - name: "Patch: HDF5 FLT16_MAX gap"
+        if: steps.ancillary-cache.outputs.cache-hit != 'true'
+        run: |
+          sed -i \
+            's#-DCMAKE_C_FLAGS="-I${FINALDIR}/include"#-DCMAKE_C_FLAGS="-I${FINALDIR}/include -DFLT16_MAX=__FLT16_MAX__"#' \
+            "$ROOT/ancillary/sources/scripts/build_extras.inc"
+
+      # (c) netcdf-c 4.9.2 fails a pointer-type check that GCC 14+ turned
+      #     into a hard error by default (mismatched struct stat / struct
+      #     _stat64 in dpathmgr.c, from newer mingw-w64 headers).
+      - name: "Patch: netcdf-c/netcdf-fortran strict pointer-type errors"
+        if: steps.ancillary-cache.outputs.cache-hit != 'true'
+        run: |
+          for f in "$ROOT/ancillary/sources/scripts/build_netcdf_c.inc" \
+                   "$ROOT/ancillary/sources/scripts/build_netcdf_f.inc"; do
+            sed -i '/-DCMAKE_BUILD_TYPE:STRING=Release \\/a\           -DCMAKE_C_FLAGS:STRING=-fpermissive \\' "$f"
+          done
+
+      # (d) The DKRZ gitlab mirror for libaec is prone to rate-limiting
+      #     anonymous/CI IPs (HTTP 429). Pre-fetch it from the GitHub
+      #     mirror instead and repackage it under the archive name/top
+      #     level directory name (libaec-v1.1.4) that build_extras.inc
+      #     expects, so the pipeline's own fetch step just finds it
+      #     already there and skips downloading it.
+      - name: "Workaround: pre-fetch libaec from GitHub mirror"
+        if: steps.ancillary-cache.outputs.cache-hit != 'true'
+        run: |
+          mkdir -p "$ROOT/ancillary/sources"
+          cd "$ROOT/ancillary/sources"
+          curl -sSL -o libaec.tmp.tar.gz \
+            "https://github.com/MathisRosenhauer/libaec/archive/refs/tags/v1.1.4.tar.gz"
+          tar xzf libaec.tmp.tar.gz
+          mv libaec-1.1.4 libaec-v1.1.4
+          tar czf libaec-v1.1.4.tar.gz libaec-v1.1.4
+          rm -rf libaec-v1.1.4 libaec.tmp.tar.gz
+
+      - name: Build ancillary dependencies
+        if: steps.ancillary-cache.outputs.cache-hit != 'true'
+        run: |
+          cd "$ROOT/ancillary"
+          export FINALDIR="$ROOT/ancillary"
+          # CC/FC must be exported explicitly: the jpeg build step only
+          # writes its Makefile "if [ \"$CC\" != \"\" ]", so without this
+          # it silently produces no Makefile at all.
+          export CC=gcc
+          export FC=gfortran
+          ./build.sh --all
+
+      # ------------------------------------------------------------------
+      # 5. Build GLM itself.
+      # ------------------------------------------------------------------
+      - name: Build GLM
+        run: |
+          cd "$ROOT/GLM"
+          ./build_glm.sh
+
+      - name: Verify glm.exe runs
+        run: |
+          cd "$ROOT/GLM"
+          PATH="$ROOT/ancillary/bin:$PATH" ./glm.exe --version
+
+      # ------------------------------------------------------------------
+      # 6. Package glm.exe with the DLLs it needs at runtime so the
+      #    artifact is self-contained (no PATH setup required).
+      # ------------------------------------------------------------------
+      - name: Assemble distributable folder
+        run: |
+          mkdir -p "$ROOT/glm_dist"
+          cp "$ROOT/GLM/glm.exe" "$ROOT/glm_dist/"
+          cp "$ROOT/ancillary/bin/libgd.dll" "$ROOT/glm_dist/"
+          cp "$ROOT/ancillary/bin/libnetcdf.dll" "$ROOT/glm_dist/"
+          cp "C:/ProgramData/mingw64/mingw64/bin/libgfortran-5.dll" "$ROOT/glm_dist/"
+          cp "C:/ProgramData/mingw64/mingw64/bin/libquadmath-0.dll" "$ROOT/glm_dist/"
+          cp "C:/ProgramData/mingw64/mingw64/bin/libgcc_s_seh-1.dll" "$ROOT/glm_dist/"
+          cp "C:/ProgramData/mingw64/mingw64/bin/libwinpthread-1.dll" "$ROOT/glm_dist/"
+
+      - name: Upload glm_dist artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: glm-windows-${{ inputs.glm_ref }}
+          path: glm_dist

--- a/build_glm.sh
+++ b/build_glm.sh
@@ -147,9 +147,9 @@ if [ "$OSTYPE" = "FreeBSD" ] ; then
   # ./fetch.sh
   # ${MAKE} || exit 1
 elif [ "$OSTYPE" = "Msys" ] ; then
-  if [ ! -d ancillary/windows ] ; then
+  if [ ! -d ancillary/lib ] ; then
     echo making windows ancillary extras
-    cd ancillary/windows
+    cd ancillary
     ./build.sh || exit 1
   fi
 fi

--- a/build_glm.sh
+++ b/build_glm.sh
@@ -190,40 +190,45 @@ cd "${CURDIR}/.."
 
 # =====================================================================
 # Package building bit
+#
+# Disabled: building a .deb here requires dh_testdir/fakeroot (debhelper)
+# to be installed, which a plain build environment doesn't have by
+# default. Uncomment if you actually want to produce a .deb from this
+# script; otherwise `make` alone already leaves glm/glm+ built above.
 
 # ***************************** Linux *********************************
-if [ "$OSTYPE" = "Linux" ] ; then
-  if [ $(lsb_release -is) = Ubuntu ] ; then
-    BINPATH=binaries/ubuntu/$(lsb_release -rs)
-    if [ ! -d "${BINPATH}" ] ; then
-      mkdir -p "${BINPATH}"/
-    fi
-    cd ${CURDIR}
-    if [ -x glm+ ] ; then
-       /bin/cp debian/control-with+ debian/control
-    else
-       /bin/cp debian/control-no+ debian/control
-    fi
-    VERSDEB=`head -1 debian/changelog | cut -f2 -d\( | cut -f1 -d-`
-    echo debian version $VERSDEB
-    if [ "$VERSION" != "$VERSDEB" ] ; then
-      echo updating debian version
-      dch --newversion ${VERSION}-0 "new version ${VERSION}"
-    fi
-    VERSRUL=`grep 'version=' debian/rules | cut -f2 -d=`
-    if [ "$VERSION" != "$VERSRUL" ] ; then
-      sed -i "s/version=$VERSRUL/version=$VERSION/" debian/rules
-    fi
-
-    fakeroot ${MAKE} -f debian/rules binary || exit 1
-
-    cd ..
-
-    mv glm*.deb ${BINPATH}/
-  else
-    BINPATH="binaries/$(lsb_release -is)/$(lsb_release -rs)"
-    echo "No package build for $(lsb_release -is)"
-  fi
-fi
+# if [ "$OSTYPE" = "Linux" ] ; then
+#   if [ $(lsb_release -is) = Ubuntu ] ; then
+#     BINPATH=binaries/ubuntu/$(lsb_release -rs)
+#     if [ ! -d "${BINPATH}" ] ; then
+#       mkdir -p "${BINPATH}"/
+#     fi
+#     cd ${CURDIR}
+#     if [ -x glm+ ] ; then
+#        /bin/cp debian/control-with+ debian/control
+#     else
+#        /bin/cp debian/control-no+ debian/control
+#     fi
+#     VERSDEB=`head -1 debian/changelog | cut -f2 -d\( | cut -f1 -d-`
+#     echo debian version $VERSDEB
+#     if [ "$VERSION" != "$VERSDEB" ] ; then
+#       echo updating debian version
+#       dch --newversion ${VERSION}-0 "new version ${VERSION}"
+#     fi
+#     VERSRUL=`grep 'version=' debian/rules | cut -f2 -d=`
+#     if [ "$VERSION" != "$VERSRUL" ] ; then
+#       sed -i "s/version=$VERSRUL/version=$VERSION/" debian/rules
+#     fi
+#
+#     fakeroot ${MAKE} -f debian/rules binary || exit 1
+#
+#     cd ..
+#
+#     mv glm*.deb ${BINPATH}/
+#   else
+#     BINPATH="binaries/$(lsb_release -is)/$(lsb_release -rs)"
+#     echo "No package build for $(lsb_release -is)"
+#   fi
+# fi
 
 exit 0


### PR DESCRIPTION
Fixed pathing in build script for Windows. Commented out .deb packaging to make script solely compiling.
Added a GitHub Actions workflow that builds for all 3 OS, but relies on changes to AED_tools in this [PR](https://github.com/AquaticEcoDynamics/AED_Tools/pull/2)